### PR TITLE
Update treatment of DY sample 

### DIFF
--- a/skimming/mutau_skim_lxplus.py
+++ b/skimming/mutau_skim_lxplus.py
@@ -167,6 +167,17 @@ class SkimProcessor(processor.ProcessorABC):
             run_dict[str(int(run))].append(int(lumi))
         dataset_run_dict[dataset] = dict(run_dict)
 
+        ## NB: to be double checked if the string identifying the buggy DY dataset is correct
+        if is_MC and dataset == 'DYJetsToLL_M-50': 
+            lhe_part = events.LHEPart
+            outcoming = lhe_part[lhe_part.status > 0]
+            lhe_z = outcoming[(outcoming.status == 2) & (outcoming.pdgId==23)]
+            out_tau_tau = outcoming[(abs(outcoming.pdgId)==15)]
+            counts_tautau = ak.num(out_tau_tau, axis=1)  
+            mask_ztautau = (counts_tautau == 2)
+            mask_zll = ~mask_ztautau
+            events = events[mask_zll]
+
         ## Trigger mask
         trigger_mask = (
                        events.HLT.PFMET120_PFMHT120_IDTight                                    |\


### PR DESCRIPTION
Main change:
remove Z→tautau events when reading the inclusive DY→LL sample, they should be replaced by the dedicated DY→TauTau samples (not included yet).
Other small changes in the cuts applied in the prompt skimming, plus minor.